### PR TITLE
Addition of handling of qualified attribute names.

### DIFF
--- a/SuperXML/Compiler.cs
+++ b/SuperXML/Compiler.cs
@@ -256,11 +256,13 @@ namespace SuperXML
                         if (reader.IsEmptyElement) goto case XmlNodeType.EndElement;
                         break;
                     case XmlNodeType.Text:
-                        element = new XmlElement(BufferCommands.StringContent)
+#pragma warning disable RECS0026 // Possible unassigned object created by 'new'
+                        new XmlElement(BufferCommands.StringContent)
                         {
                             Value = reader.Value,
                             Parent = element
                         };
+#pragma warning restore RECS0026 // Possible unassigned object created by 'new'
                         break;
                     case XmlNodeType.EndElement:
                         element = element.Parent;

--- a/SuperXML/Compiler.cs
+++ b/SuperXML/Compiler.cs
@@ -256,7 +256,7 @@ namespace SuperXML
                         if (reader.IsEmptyElement) goto case XmlNodeType.EndElement;
                         break;
                     case XmlNodeType.Text:
-                        new XmlElement(BufferCommands.StringContent)
+                        element = new XmlElement(BufferCommands.StringContent)
                         {
                             Value = reader.Value,
                             Parent = element
@@ -447,7 +447,15 @@ namespace SuperXML
                             foreach (var attribute in Attributes.Where(attribute => attribute.Name != RepeaterKey
                                                                                     && attribute.Name != IfKey))
                             {
-                                writer.WriteAttributeString(attribute.Name, Inject(attribute.Value));
+                                if (attribute.Name.Contains(":"))
+                                {
+                                    var names = attribute.Name.Split(':');
+                                    writer.WriteAttributeString(names[0], names[1], null, Inject(attribute.Value));
+                                }
+                                else
+                                {
+                                    writer.WriteAttributeString(attribute.Name, Inject(attribute.Value));
+                                }
                             }
                             foreach (var child in Children)
                             {

--- a/SuperXML/Compiler.cs
+++ b/SuperXML/Compiler.cs
@@ -321,7 +321,7 @@ namespace SuperXML
             /// Scope of current Element.
             /// </summary>
             public Dictionary<string, dynamic> Scope { get; set; }
-            public dynamic GetValueFromScope(string propertyName)
+            public dynamic GetValueFromScope(string propertyName, string format = null)
             {
                 try
                 {
@@ -360,7 +360,9 @@ namespace SuperXML
                         level++;
                     }
 
-                    return property.GetValue(obj);
+                    if (string.IsNullOrWhiteSpace(format))
+                        return property.GetValue(obj);
+                    return property.GetValue(obj).ToString(format);
                 }
                 catch (Exception)
                 {
@@ -479,6 +481,7 @@ namespace SuperXML
                     Items = new List<CExpressionItem>();
                     Parent = parent;
                     OriginalExpression = expression;
+                    CExpressionItem item = null;
 
                     var read = new List<char>();
                     var type = LectureType.Unknow;
@@ -488,6 +491,19 @@ namespace SuperXML
                         switch (type)
                         {
                             case LectureType.Variable:
+                                if (c == ':')
+                                {
+                                    var l = new string(read.ToArray());
+                                    item = new CExpressionItem
+                                    {
+                                        FromScope = !KeyWords.Contains(l),
+                                        Value = l
+                                    };
+                                    Items.Add(item);
+                                    read.Clear();
+                                    type = LectureType.Format;
+                                    continue;
+                                }
                                 if (!ValidContentName.Contains(c))
                                 {
                                     var l = new string(read.ToArray());
@@ -549,7 +565,7 @@ namespace SuperXML
                         }
                         read.Add(c);
                     }
-                    if (type != LectureType.Filter)
+                    if (type != LectureType.Filter && type != LectureType.Format)
                     {
                         Items.Add(new CExpressionItem
                         {
@@ -557,9 +573,13 @@ namespace SuperXML
                             Value = new string(read.ToArray())
                         });
                     }
-                    else
+                    else if(type == LectureType.Filter) 
                     {
                         Filter = new string(read.ToArray()).Replace("|", "").Trim();
+                    }
+                    else if (type == LectureType.Format)
+                    {
+                        item.Format = new string(read.ToArray()).Trim();
                     }
                 }
 
@@ -580,12 +600,15 @@ namespace SuperXML
                             sb.Append("[p");
                             sb.Append(p);
                             sb.Append("]");
-                            parameters.Add("p" + p, Parent.GetValueFromScope(i.Value) ?? false);   
+                            parameters.Add("p" + p, Parent.GetValueFromScope(i.Value, i.Format) ?? false);   
                             p++;
                         }
                         else
                         {
-                            sb.Append(i.Value);
+                            if (string.IsNullOrWhiteSpace(i.Format))
+                                sb.Append(i.Value);
+                            else
+                                sb.Append(i.Value.ToString());
                         }
                     }
 
@@ -615,6 +638,7 @@ namespace SuperXML
             {
                 public bool FromScope { get; set; }
                 public string Value { get; set; }
+                public string Format { get; set; }
             }
         }
 
@@ -670,7 +694,7 @@ namespace SuperXML
 
         private enum LectureType
         {
-            Variable, String, Filter, Unknow, Constant
+            Variable, String, Filter, Unknow, Constant, Format
         }
     }
 }

--- a/Test/MainWindow.xaml.cs
+++ b/Test/MainWindow.xaml.cs
@@ -59,7 +59,8 @@ namespace Test
                     {
                         Name = null,
                         Age = 10
-                    }
+                    },
+                    Now = DateTime.Now
                 });
 
             var startedTime = DateTime.Now;
@@ -99,6 +100,7 @@ namespace Test
             public List<int> Bounds { get; set; }
             public List<User> Users { get; set; } 
             public User NullUser { get; set; }
+            public DateTime Now { get; set; }
         }
     }
 }

--- a/Test/testFile.xml
+++ b/Test/testFile.xml
@@ -1,6 +1,5 @@
-﻿
-<document>
-  <name>my name is {{m.Name}}</name>
+﻿<document xmlns:xlink="http://www.w3.org/1999/xlink">
+  <name xlink:type="resource" >my name is {{m.Name}}</name>
   <width>{{m.Width}}</width>
   <height>{{m.Height}}</height>
   <area>{{m.Width*m.Height}}</area>

--- a/Test/testFile.xml
+++ b/Test/testFile.xml
@@ -3,6 +3,7 @@
   <width>{{m.Width}}</width>
   <height>{{m.Height}}</height>
   <area>{{m.Width*m.Height}}</area>
+  <dateTime>{{m.Now:yyyy-MM-ddTHH:mm:sszzz}}</dateTime>
   <padding>
     <bound sxRepeat="bound in m.Bounds">{{bound}}</bound>
   </padding>


### PR DESCRIPTION
Attribute names with a colon in the name broke the code; the WriteAttributeString(name, value) verified that the name parameter did not have colon in its name. By handling this with prefixes, this is now supported. 

Typically xmlns:xlink="uri to named namespace here" and xlink:type="resource" now works.

Also, a presumed bug was found; a XmlElement was newed up at one place in the code and not assigned to a variable, hence promptly discarded. It is now saved in the element-variable.
