### PR TITLE
Allow compiling to TextWriter

### DIFF
--- a/SuperXML/Compiler.cs
+++ b/SuperXML/Compiler.cs
@@ -122,33 +122,48 @@ namespace SuperXML
             }
         }
 
-        /// <summary>
-        /// Compiles a Xml template with specified URI.
-        /// </summary>
-        /// <param name="uri"></param>
-        /// <param name="root">
-        ///     Set the root to compile, to improve performance. 
-        ///     example: x => x.Children.First(y => x.Name == "MyElement")
-        /// </param>
-        /// <returns></returns>
-        public string CompileXml(string uri, Func<XmlElement, XmlElement> root = null)
-        {
-            using (var reader = XmlReader.Create(uri))
-            {
-                var output = new StringBuilder();
-                var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
-                using (var writer = XmlWriter.Create(output, ws))
-                {
-                    var compiled = _readXml(reader);
-                    if (root != null)
-                    {
-                        compiled = root(compiled);
-                    }
-                    compiled.Run(writer);
-                }
-                return output.ToString();
-            }
-        }
+		/// <summary>
+		/// Compiles a Xml template with specified URI.
+		/// </summary>
+		/// <param name="uri"></param>
+		/// <param name="root">
+		///     Set the root to compile, to improve performance. 
+		///     example: x => x.Children.First(y => x.Name == "MyElement")
+		/// </param>
+		/// <returns></returns>
+		public string CompileXml(string uri, Func<XmlElement, XmlElement> root = null)
+		{
+			var output = new StringBuilder();
+			StringWriter writer = new StringWriter(output);
+			CompileXml(uri, writer, null);
+			return output.ToString();
+		}
+
+		/// <summary>
+		/// Compiles a Xml template with specified URI.
+		/// </summary>
+		/// <param name="uri"></param>
+		/// <param name="root">
+		///     Set the root to compile, to improve performance. 
+		///     example: x => x.Children.First(y => x.Name == "MyElement")
+		/// </param>
+		/// <returns></returns>
+		public void CompileXml(string uri, TextWriter output, Func<XmlElement, XmlElement> root = null)
+		{
+			using (var reader = XmlReader.Create(uri))
+			{
+				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+				using (var writer = XmlWriter.Create(output, ws))
+				{
+					var compiled = _readXml(reader);
+					if (root != null)
+					{
+						compiled = root(compiled);
+					}
+					compiled.Run(writer);
+				}
+			}
+		}
 
         /// <summary>
         /// Compiles a Xml template using the specified stream with default settings. 
@@ -161,22 +176,38 @@ namespace SuperXML
         /// <returns></returns>
         public string CompileXml(Stream stream, Func<XmlElement, XmlElement> root = null)
         {
-            using (var reader = XmlReader.Create(stream))
-            {
-                var output = new StringBuilder();
-                var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
-                using (var writer = XmlWriter.Create(output, ws))
-                {
-                    var compiled = _readXml(reader);
-                    if (root != null)
-                    {
-                        compiled = root(compiled);
-                    }
-                    compiled.Run(writer);
-                }
-                return output.ToString();
-            }
+			var output = new StringBuilder();
+			StringWriter writer = new StringWriter(output);
+			CompileXml(stream, writer, null);
+			return output.ToString();
         }
+
+		/// <summary>
+		/// Compiles a Xml template using the specified stream with default settings. 
+		/// </summary>
+		/// <param name="input"></param>
+		/// <param name="root">
+		///     Set the root to compile, to improve performance. 
+		///     example: x => x.Children.First(y => x.Name == "MyElement")
+		/// </param>
+		/// <param name="output"></param>
+		/// <returns></returns>
+		public void CompileXml(Stream input, TextWriter output, Func<XmlElement, XmlElement> root = null)
+		{
+			using (var reader = XmlReader.Create(input))
+			{
+				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+				using (var writer = XmlWriter.Create(output, ws))
+				{
+					var compiled = _readXml(reader);
+					if (root != null)
+					{
+						compiled = root(compiled);
+					}
+					compiled.Run(writer);
+				}
+			}
+		}
 
         /// <summary>
         /// Compiles a Xml template by using the specified text reader. 
@@ -189,22 +220,37 @@ namespace SuperXML
         /// <returns></returns>
         public string CompileXml(TextReader textReader, Func<XmlElement, XmlElement> root = null)
         {
-            using (var reader = XmlReader.Create(textReader))
-            {
-                var output = new StringBuilder();
-                var ws = XmlWriterSettings ?? new XmlWriterSettings {Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true};
-                using (var writer = XmlWriter.Create(output, ws))
-                {
-                    var compiled = _readXml(reader);
-                    if (root != null)
-                    {
-                        compiled = root(compiled);
-                    }
-                    compiled.Run(writer);
-                }
-                return output.ToString();
-            }
+			var output = new StringBuilder();
+			StringWriter writer = new StringWriter(output);
+			CompileXml(textReader, writer, null);
+			return output.ToString();
         }
+
+		/// <summary>
+		/// Compiles a Xml template by using the specified text reader. 
+		/// </summary>
+		/// <param name="textReader"></param>
+		/// <param name="root">
+		///     Set the root to compile, to improve performance. 
+		///     example: x => x.Children.First(y => x.Name == "MyElement")
+		/// </param>
+		/// <returns></returns>
+		public void CompileXml(TextReader textReader, TextWriter output, Func<XmlElement, XmlElement> root = null)
+		{
+			using (var reader = XmlReader.Create(textReader))
+			{
+				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+				using (var writer = XmlWriter.Create(output, ws))
+				{
+					var compiled = _readXml(reader);
+					if (root != null)
+					{
+						compiled = root(compiled);
+					}
+					compiled.Run(writer);
+				}
+			}
+		}
 
         /// <summary>
         /// Compiles a Xml template with a specified XmlReader

--- a/SuperXML/Compiler.cs
+++ b/SuperXML/Compiler.cs
@@ -52,21 +52,21 @@ namespace SuperXML
             Filters = new Dictionary<string, Func<object, string>>
             {
                 {"currency", x =>
-					{
-						//this is simple and dirty to support all numeric types.
-						var s = x.ToString();
-						double d;
-						double.TryParse(s, out d);
-						return d.ToString("C");
-					}
-				}
+                    {
+                        //this is simple and dirty to support all numeric types.
+                        var s = x.ToString();
+                        double d;
+                        double.TryParse(s, out d);
+                        return d.ToString("C");
+                    }
+                }
             };
         }
 
         public static string RepeaterKey { get; set; }
         public static string IfKey { get; set; }
         public static string TemplateKey  { get; set; }
-		public static Dictionary<string, Func<object, string>> Filters { get; private set; }
+        public static Dictionary<string, Func<object, string>> Filters { get; private set; }
 
         private static readonly Regex IsExpressionRegex;
         private static readonly Regex ForEachRegex;
@@ -122,48 +122,48 @@ namespace SuperXML
             }
         }
 
-		/// <summary>
-		/// Compiles a Xml template with specified URI.
-		/// </summary>
-		/// <param name="uri"></param>
-		/// <param name="root">
-		///     Set the root to compile, to improve performance. 
-		///     example: x => x.Children.First(y => x.Name == "MyElement")
-		/// </param>
-		/// <returns></returns>
-		public string CompileXml(string uri, Func<XmlElement, XmlElement> root = null)
-		{
-			var output = new StringBuilder();
-			StringWriter writer = new StringWriter(output);
-			CompileXml(uri, writer, null);
-			return output.ToString();
-		}
+        /// <summary>
+        /// Compiles a Xml template with specified URI.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="root">
+        ///     Set the root to compile, to improve performance. 
+        ///     example: x => x.Children.First(y => x.Name == "MyElement")
+        /// </param>
+        /// <returns></returns>
+        public string CompileXml(string uri, Func<XmlElement, XmlElement> root = null)
+        {
+            var output = new StringBuilder();
+            StringWriter writer = new StringWriter(output);
+            CompileXml(uri, writer, null);
+            return output.ToString();
+        }
 
-		/// <summary>
-		/// Compiles a Xml template with specified URI.
-		/// </summary>
-		/// <param name="uri"></param>
-		/// <param name="root">
-		///     Set the root to compile, to improve performance. 
-		///     example: x => x.Children.First(y => x.Name == "MyElement")
-		/// </param>
-		/// <returns></returns>
-		public void CompileXml(string uri, TextWriter output, Func<XmlElement, XmlElement> root = null)
-		{
-			using (var reader = XmlReader.Create(uri))
-			{
-				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
-				using (var writer = XmlWriter.Create(output, ws))
-				{
-					var compiled = _readXml(reader);
-					if (root != null)
-					{
-						compiled = root(compiled);
-					}
-					compiled.Run(writer);
-				}
-			}
-		}
+        /// <summary>
+        /// Compiles a Xml template with specified URI.
+        /// </summary>
+        /// <param name="uri"></param>
+        /// <param name="root">
+        ///     Set the root to compile, to improve performance. 
+        ///     example: x => x.Children.First(y => x.Name == "MyElement")
+        /// </param>
+        /// <returns></returns>
+        public void CompileXml(string uri, TextWriter output, Func<XmlElement, XmlElement> root = null)
+        {
+            using (var reader = XmlReader.Create(uri))
+            {
+                var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+                using (var writer = XmlWriter.Create(output, ws))
+                {
+                    var compiled = _readXml(reader);
+                    if (root != null)
+                    {
+                        compiled = root(compiled);
+                    }
+                    compiled.Run(writer);
+                }
+            }
+        }
 
         /// <summary>
         /// Compiles a Xml template using the specified stream with default settings. 
@@ -176,38 +176,38 @@ namespace SuperXML
         /// <returns></returns>
         public string CompileXml(Stream stream, Func<XmlElement, XmlElement> root = null)
         {
-			var output = new StringBuilder();
-			StringWriter writer = new StringWriter(output);
-			CompileXml(stream, writer, null);
-			return output.ToString();
+            var output = new StringBuilder();
+            StringWriter writer = new StringWriter(output);
+            CompileXml(stream, writer, null);
+            return output.ToString();
         }
 
-		/// <summary>
-		/// Compiles a Xml template using the specified stream with default settings. 
-		/// </summary>
-		/// <param name="input"></param>
-		/// <param name="root">
-		///     Set the root to compile, to improve performance. 
-		///     example: x => x.Children.First(y => x.Name == "MyElement")
-		/// </param>
-		/// <param name="output"></param>
-		/// <returns></returns>
-		public void CompileXml(Stream input, TextWriter output, Func<XmlElement, XmlElement> root = null)
-		{
-			using (var reader = XmlReader.Create(input))
-			{
-				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
-				using (var writer = XmlWriter.Create(output, ws))
-				{
-					var compiled = _readXml(reader);
-					if (root != null)
-					{
-						compiled = root(compiled);
-					}
-					compiled.Run(writer);
-				}
-			}
-		}
+        /// <summary>
+        /// Compiles a Xml template using the specified stream with default settings. 
+        /// </summary>
+        /// <param name="input"></param>
+        /// <param name="root">
+        ///     Set the root to compile, to improve performance. 
+        ///     example: x => x.Children.First(y => x.Name == "MyElement")
+        /// </param>
+        /// <param name="output"></param>
+        /// <returns></returns>
+        public void CompileXml(Stream input, TextWriter output, Func<XmlElement, XmlElement> root = null)
+        {
+            using (var reader = XmlReader.Create(input))
+            {
+                var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+                using (var writer = XmlWriter.Create(output, ws))
+                {
+                    var compiled = _readXml(reader);
+                    if (root != null)
+                    {
+                        compiled = root(compiled);
+                    }
+                    compiled.Run(writer);
+                }
+            }
+        }
 
         /// <summary>
         /// Compiles a Xml template by using the specified text reader. 
@@ -220,37 +220,37 @@ namespace SuperXML
         /// <returns></returns>
         public string CompileXml(TextReader textReader, Func<XmlElement, XmlElement> root = null)
         {
-			var output = new StringBuilder();
-			StringWriter writer = new StringWriter(output);
-			CompileXml(textReader, writer, null);
-			return output.ToString();
+            var output = new StringBuilder();
+            StringWriter writer = new StringWriter(output);
+            CompileXml(textReader, writer, null);
+            return output.ToString();
         }
 
-		/// <summary>
-		/// Compiles a Xml template by using the specified text reader. 
-		/// </summary>
-		/// <param name="textReader"></param>
-		/// <param name="root">
-		///     Set the root to compile, to improve performance. 
-		///     example: x => x.Children.First(y => x.Name == "MyElement")
-		/// </param>
-		/// <returns></returns>
-		public void CompileXml(TextReader textReader, TextWriter output, Func<XmlElement, XmlElement> root = null)
-		{
-			using (var reader = XmlReader.Create(textReader))
-			{
-				var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
-				using (var writer = XmlWriter.Create(output, ws))
-				{
-					var compiled = _readXml(reader);
-					if (root != null)
-					{
-						compiled = root(compiled);
-					}
-					compiled.Run(writer);
-				}
-			}
-		}
+        /// <summary>
+        /// Compiles a Xml template by using the specified text reader. 
+        /// </summary>
+        /// <param name="textReader"></param>
+        /// <param name="root">
+        ///     Set the root to compile, to improve performance. 
+        ///     example: x => x.Children.First(y => x.Name == "MyElement")
+        /// </param>
+        /// <returns></returns>
+        public void CompileXml(TextReader textReader, TextWriter output, Func<XmlElement, XmlElement> root = null)
+        {
+            using (var reader = XmlReader.Create(textReader))
+            {
+                var ws = XmlWriterSettings ?? new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8, OmitXmlDeclaration = true };
+                using (var writer = XmlWriter.Create(output, ws))
+                {
+                    var compiled = _readXml(reader);
+                    if (root != null)
+                    {
+                        compiled = root(compiled);
+                    }
+                    compiled.Run(writer);
+                }
+            }
+        }
 
         /// <summary>
         /// Compiles a Xml template with a specified XmlReader
@@ -333,7 +333,7 @@ namespace SuperXML
                 Type = type;
             }
 
-			private BufferCommands Type { get; set; }
+            private BufferCommands Type { get; set; }
             /// <summary>
             /// Name of the Element
             /// </summary>
@@ -348,21 +348,21 @@ namespace SuperXML
             /// <summary>
             /// Attributes in the Element
             /// </summary>
-			public List<XmlAttribute> Attributes { get; private set; }
+            public List<XmlAttribute> Attributes { get; private set; }
             public XmlElement Parent
             {
                 get { return _parent; }
                 set
                 {
                     _parent = value;
-					if ((object)Parent != null)
-						_parent.Children.Add(this);
+                    if ((object)Parent != null)
+                        _parent.Children.Add(this);
                 }
             }
             /// <summary>
             /// Gets the children of this element
             /// </summary>
-			public List<XmlElement> Children { get; private set; }
+            public List<XmlElement> Children { get; private set; }
             /// <summary>
             /// Scope of current Element.
             /// </summary>
@@ -601,10 +601,10 @@ namespace SuperXML
                     }
                 }
 
-				private List<CExpressionItem> Items { get; set; }
-				private XmlElement Parent { get; set; }
-				private string OriginalExpression { get; set; }
-				private string Filter { get; set; }
+                private List<CExpressionItem> Items { get; set; }
+                private XmlElement Parent { get; set; }
+                private string OriginalExpression { get; set; }
+                private string Filter { get; set; }
 
                 public string Evaluate()
                 {
@@ -675,8 +675,8 @@ namespace SuperXML
                 }
             }
 
-			public string Name { get; private set; }
-			public List<string> Children { get; private set; }
+            public string Name { get; private set; }
+            public List<string> Children { get; private set; }
 
             public dynamic GetValue(dynamic obj)
             {


### PR DESCRIPTION
Hello,

my resulting XML file was too large (400MB) to fit into a StringBuilder, so SuperXML crashed with an `OutOfMemoryException`.
As I want to write the file on the HDD anyway, I added some Compile() methods that take a `TextWriter` as argument for output. This `TextWriter` can be a `StringWriter + StringBuilder` as it is still used in the string-returning methods, but it can also be a writer to a file.

I didn't figure out how to remove/skip the `<xs:string>` tags when taking a string (not an uri) as input, so I didn't extend those methods. It would be nice (and consistent) when you could add a method for this case, too.

Unfortunately I had to remove the C#6 code to make it work in my old Visual Studio (upgrade impossible). I recommend to not merge this PR but only the commit e29816a515bac014a9396868f119f38cccbe43f7.
